### PR TITLE
Added exclude optimization with --xoptim [exclusion...] to exclude specific optimizations

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -9,6 +9,7 @@ import { compressCSS } from './compressors/css.js';
 import { compressJS } from './compressors/js.js';
 import { compressHTML } from './compressors/html.js';
 import { compressImage } from './compressors/images.js';
+import { CLIOptions } from './config.js';
 
 const processFile = async (file: string, stats: Stats): Promise<void> => {
   let writeData: Buffer | string | undefined = undefined;
@@ -75,7 +76,9 @@ const processFile = async (file: string, stats: Stats): Promise<void> => {
   $state.reportSummary(result);
 };
 
-export async function compressFolder(exclude: string): Promise<void> {
+export async function compressFolder(options: CLIOptions): Promise<void> {
+  const { exclude } = options;
+
   const spinner = ora(getProgressText()).start();
 
   const globs = ['**/**'];

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,19 @@ export type Options = {
   };
 };
 
+export type CLIOptions = {
+  include?: string;
+  exclude?: string;
+  nowrite?: boolean;
+  fast?: boolean;
+  fail?: boolean;
+  xoptim?: string[];
+  onlyoptim?: boolean;
+  onlycomp?: boolean;
+  cleanache?: boolean;
+  nocache?: boolean;
+};
+
 const default_options: Options = {
   image: {
     embed_size: 1500,

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ program
   .option('--nowrite', 'No write')
   .option('--fast', 'Go fast. Mostly no compression just checks for issues.')
   .option('--fail', 'Exits with a non-zero return code if issues.')
+  .option('--xoptim [exclusion...]', 'Exclude specific optimizations.')
   .option('--onlyoptim', 'Only optimize (PASS 1).')
   .option('--onlycomp', 'Only compress (PASS 2).')
   .option('--cleancache', 'Clean cache before running')
@@ -59,14 +60,14 @@ program
     if (!options.onlycomp) {
       printTitle('PASS 1 - Optimizing');
       console.time('Done');
-      await optimize(options.include, options.exclude);
+      await optimize(options);
       console.timeEnd('Done');
     }
 
     if (!options.onlyoptim && !options.fast) {
       printTitle('PASS 2 - Compressing the rest');
       console.time('Done');
-      await compressFolder(options.exclude);
+      await compressFolder(options);
       console.timeEnd('Done');
     }
 


### PR DESCRIPTION
## Context

I love jampack but our team was trying to implement it in our build workflow. After some test we got an use case that might be a problem to other people.

The problem was that one of the optimisation made by jampack `Sets width and height attributes` broke most of our webpages images.
>  We can't make the manual update in all of our webpages because we have a lot of them

Therefore we was looking in a way to disable specific features of jampack in order to be able to use the other optimisations that works as a charm ✨. 

But we only have the option to disable all the optimisation with `--onlycomp` and that is not convenient because we just wanted to disable one of them 😓 

## Example
Here you can see that the images are malformed duo the `Sets width and height attributes` optimization.

### Original:
<img width="1728" alt="Screenshot 2023-03-28 at 00 34 42" src="https://user-images.githubusercontent.com/59401547/228082019-176cb7bc-ba07-40c2-981a-b6e93ed19c9b.png">

### After jampack:
![image](https://user-images.githubusercontent.com/59401547/228081765-e700461a-df7a-4c38-9895-b3d23d95d4df.png)

## Feature (Solution)

After taking a look to the code we have made an update in jampack in order to add the `--xoptim` (`x` for exclude) which receives an array of  strings which will let you to exclude specific optimisations. With this option if you have any use case that  needs to exclude some optimisation you can exclude it very easy with this new option!

With this update we will be able to just run `jampack --xoptim imgsize` and this problem will just disappear letting us having all the other optimisations without having to make an update to each of our webpages 🚀 

### All possible exclusions

```ts
type ExcludeOptimization = {
  img?: boolean;
  imglazy?: boolean;
  imgcompress?: boolean;
  imgembed?: boolean;
  imgsize?: boolean;
  imgsrcset?: boolean;
  imgpicture?: boolean;
  iframe?: boolean;
};
```
### Feature usage
The usage of this new option will be `jampack --xoptim [exclusion...]` being `[exclusion...]` any of the strings mentioned above. 

### Feature examples
- `jampack --xoptim img` => Exclude all `image` optimisations
- `jampack --xoptim iframe imgsrcset` => Exclude `iframe` and `image src set` optimisation

As you can see in the examples you can exclude as much features as you like!

## Conclusion

I think that this feature could be very useful to any user that needs to exclude any specific optimisation!

> Also I have made a small refactor to how the `options` are sent to the functions in order to be able to get more information of the cli options inside the `optimize` and `compressFolder` function

I hope you like the idea, let me know that you think!