### PR TITLE
chore: @types/svgo and @types/sharp are deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divriots/jampack",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Packer for static websites",
   "author": "Georges Gomes @georges-gomes",
   "bin": {
@@ -19,9 +19,6 @@
     "@divriots/cheerio": "1.0.0-rc.12",
     "@proload/core": "^0.3.3",
     "@swc/core": "^1.3.57",
-    "@types/html-minifier-terser": "^7.0.0",
-    "@types/sharp": "^0.32.0",
-    "@types/svgo": "^3.0.0",
     "commander": "^10.0.1",
     "deepmerge": "^4.3.1",
     "file-type": "^18.4.0",
@@ -37,6 +34,7 @@
     "table": "^6.8.1"
   },
   "devDependencies": {
+    "@types/html-minifier-terser": "^7.0.0",
     "@types/node": "^16.18.28",
     "shx": "^0.3.3",
     "ts-node": "^10.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,6 @@ specifiers:
   '@swc/core': ^1.3.57
   '@types/html-minifier-terser': ^7.0.0
   '@types/node': ^16.18.28
-  '@types/sharp': ^0.32.0
-  '@types/svgo': ^3.0.0
   commander: ^10.0.1
   deepmerge: ^4.3.1
   file-type: ^18.4.0
@@ -30,9 +28,6 @@ dependencies:
   '@divriots/cheerio': 1.0.0-rc.12
   '@proload/core': 0.3.3
   '@swc/core': 1.3.57
-  '@types/html-minifier-terser': 7.0.0
-  '@types/sharp': 0.32.0
-  '@types/svgo': 3.0.0
   commander: 10.0.1
   deepmerge: 4.3.1
   file-type: 18.4.0
@@ -48,6 +43,7 @@ dependencies:
   table: 6.8.1
 
 devDependencies:
+  '@types/html-minifier-terser': 7.0.0
   '@types/node': 16.18.28
   shx: 0.3.4
   ts-node: 10.9.1_nk2zilt6v2gmxbgcnddtneahvq
@@ -278,25 +274,11 @@ packages:
 
   /@types/html-minifier-terser/7.0.0:
     resolution: {integrity: sha512-hw3bhStrg5e3FQT8qZKCJTrzt/UbEaunU1xRWJ+aNOTmeBMvE3S4Ml2HiiNnZgL8izu0LFVkHUoPFXL1s5QNpQ==}
-    dev: false
+    dev: true
 
   /@types/node/16.18.28:
     resolution: {integrity: sha512-SNMfiPqsiPoYfmyi+2qnDO4nZyMIOCab/CW+Slcml0lhIzkOizYzWtt/A7tgB3TSitd+YJKi8fSC2Cpm/VCp7A==}
     dev: true
-
-  /@types/sharp/0.32.0:
-    resolution: {integrity: sha512-OOi3kL+FZDnPhVzsfD37J88FNeZh6gQsGcLc95NbeURRGvmSjeXiDcyWzF2o3yh/gQAUn2uhh/e+CPCa5nwAxw==}
-    deprecated: This is a stub types definition. sharp provides its own type definitions, so you do not need this installed.
-    dependencies:
-      sharp: 0.32.1
-    dev: false
-
-  /@types/svgo/3.0.0:
-    resolution: {integrity: sha512-G5qLWNq/rMvSM1EyY4E2iEd+s9km/PxLkzPkA2lghrgWJ2jrVMuB1ZsGOzL4YAWCy5sAoUw7SEQseHE2qypF2w==}
-    deprecated: This is a stub types definition. svgo provides its own type definitions, so you do not need this installed.
-    dependencies:
-      svgo: 3.0.2
-    dev: false
 
   /acorn-walk/8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}


### PR DESCRIPTION
svgo and sharp are released with their typings (also
shouldnt be dependencies but devdependencies)
