### PR TITLE
feat: default meta charset and position

### DIFF
--- a/packages/www/public/features/optimize-images-cdn/index.md
+++ b/packages/www/public/features/optimize-images-cdn/index.md
@@ -42,7 +42,7 @@ image: {
 
 | process: | Description |
 |-----------|-------------|
-| `'off'` | It will ignore cdn images threat them as [external images](/features/features/optimize-images-external). |
+| `'off'` | It will ignore cdn images and treat them as [external images](/features/features/optimize-images-external). |
 | `'optimize'` | It will detect external images as coming from CDN and generate srcsets images url on the CDN. |
 
 ## Example

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -147,7 +147,12 @@ async function analyse(file: string): Promise<void> {
 
   const charsetElements$ = heads.find('meta[charset]');
   switch (charsetElements$.length) {
-    case 0: // utf-8 is the default in html5, could check DOCTYPE is set?
+    case 0:
+      $state.reportIssue(file, {
+        type: 'fix',
+        msg: 'Adding missing <meta charset="utf-8"> to the top of the <head>',
+      });
+      heads.prepend('<meta charset="utf-8">');
       break;
     case 1:
       if (charsetElements$.prev().length) {

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -135,22 +135,26 @@ async function analyse(file: string): Promise<void> {
   //
   let prependToHead = '';
   let appendToHead = '';
+  let heads = $('head'); // always exists because doc loaded with isDocument=true (default)
 
   if (config.html.add_css_reset_as === 'inline') {
     prependToHead += `<style>:where(img){height:auto;}</style>`;
   }
-
   if (prependToHead || appendToHead) {
-    let heads = $('head');
-    if (heads.length === 0) {
-      // head tag doesn't exist
-      $('html')?.prepend(`<head></head>`);
-    }
-    heads = $('head');
-
-    // head tag exist
     if (prependToHead) heads.prepend(prependToHead);
     if (appendToHead) heads.append(appendToHead);
+  }
+
+  const charsetElements$ = heads.find('meta[charset]');
+  switch (charsetElements$.length) {
+    case 0: // utf-8 is the default in html5, could check DOCTYPE is set?
+      break;
+    case 1:
+      if (charsetElements$.prev().length) heads.prepend(charsetElements$);
+      break;
+    default:
+      charsetElements$.remove();
+      heads.prepend(charsetElements$.first());
   }
 
   // Add to <body>

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -150,9 +150,19 @@ async function analyse(file: string): Promise<void> {
     case 0: // utf-8 is the default in html5, could check DOCTYPE is set?
       break;
     case 1:
-      if (charsetElements$.prev().length) heads.prepend(charsetElements$);
+      if (charsetElements$.prev().length) {
+        $state.reportIssue(file, {
+          type: 'fix',
+          msg: 'Moving <meta charset> to the top of the <head>',
+        });
+        heads.prepend(charsetElements$);
+      }
       break;
     default:
+      $state.reportIssue(file, {
+        type: 'fix',
+        msg: 'Multiple <meta charset> found in the <head>: taking only the first one and deleting the others',
+      });
       charsetElements$.remove();
       heads.prepend(charsetElements$.first());
   }


### PR DESCRIPTION
- if meta charset is not specified, noop => html5 defaults to utf-8
(although jampack does not enforce it, so maybe could check it is html5)
- no matter what happens, have it first in the <head> element
as that is best practice
