### PR TITLE
feat: disable default attribute sorting

### DIFF
--- a/src/compressors/html.ts
+++ b/src/compressors/html.ts
@@ -1,6 +1,7 @@
 import { minify } from 'html-minifier-terser';
 import { compressCSS } from './css.js';
 import { compressJS } from './js.js';
+import config from '../config.js';
 
 async function minifyJSinHTML(originalCode: string): Promise<string> {
   const newCode = await compressJS(originalCode);
@@ -27,7 +28,7 @@ export async function compressHTML(originalCode: Buffer): Promise<Buffer> {
     minifyCSS: minifyCSSinHTML,
     minifyJS: minifyJSinHTML,
     sortClassName: true,
-    sortAttributes: true,
+    sortAttributes: config.html.sort_attributes,
   });
 
   if (newhtmlData) return Buffer.from(newhtmlData, 'utf-8');

--- a/src/config-default.ts
+++ b/src/config-default.ts
@@ -3,6 +3,7 @@ import { Options } from './config-types.js';
 const default_options: Options = {
   html: {
     add_css_reset_as: 'inline',
+    sort_attributes: false,
   },
   css: {
     inline_critical_css: false,

--- a/src/config-types.ts
+++ b/src/config-types.ts
@@ -13,6 +13,7 @@ export type Options = {
       ":where(img){height:auto}"
     */
     add_css_reset_as: 'inline' | 'off';
+    sort_attributes: boolean;
   };
   js: {
     compressor: 'esbuild' | 'swc'; // swc have smaller result but can break code (seen with SvelteKit code)


### PR DESCRIPTION
Still can be enabled with html.sort_attributes option
