### PR TITLE
disable adding svg height/width attrs by default, add option

### DIFF
--- a/src/config-default.ts
+++ b/src/config-default.ts
@@ -55,6 +55,7 @@ const default_options: Options = {
     },
     svg: {
       optimization: true,
+      add_width_and_height: false,
     },
   },
   misc: {

--- a/src/config-types.ts
+++ b/src/config-types.ts
@@ -65,6 +65,7 @@ export type Options = {
     };
     svg: {
       optimization: boolean;
+      add_width_and_height: boolean;
     };
   };
   misc: {

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -839,6 +839,11 @@ async function setImageSize(
   let height = img.attr('height');
   let width_new: number | undefined = undefined;
   let height_new: number | undefined = undefined;
+  const img_fmt = await image.getExt();
+
+  if (img_fmt === 'svg' && !config.image.svg.add_width_and_height) {
+    return [];
+  }
 
   // Check valid values
   if (width !== undefined) {
@@ -893,7 +898,7 @@ async function setImageSize(
   } else {
     // No width or height provided - set both to image size
 
-    if ((await image.getExt()) === 'svg') {
+    if (img_fmt === 'svg') {
       // svg with no height and width has special sizing by browsers
       // They size it inside 300x150 unless they have width and height
       // attributes


### PR DESCRIPTION
I just went with a simple short-circuit, seemed like the easiest option.