### PR TITLE
feat: allow cdn.src_include to override isLocal()

### DIFF
--- a/src/config-default.ts
+++ b/src/config-default.ts
@@ -26,7 +26,7 @@ const default_options: Options = {
     },
     cdn: {
       process: 'off',
-      src_include: /^.*$/,
+      src_include: null,
       src_exclude: null,
     },
     compress: true,

--- a/src/config-types.ts
+++ b/src/config-types.ts
@@ -43,7 +43,7 @@ export type Options = {
       process:
         | 'off' //default
         | 'optimize';
-      src_include: RegExp;
+      src_include: RegExp | null;
       src_exclude: RegExp | null;
       transformer?: UrlTransformer; // Custom 'unpic' cdn url transformer, if not present it will be determined by 'unpic' based on original url
     };

--- a/src/utils/resource.ts
+++ b/src/utils/resource.ts
@@ -155,7 +155,6 @@ export class Resource {
 }
 
 export function isLocal(src: string) {
-   if (src.startsWith('/cdn_cgi/')) return false;
   const u = url.parse(src);
   return !u.host;
 }


### PR DESCRIPTION
That way user can decide that "/cdn-cgi/" prefix needs to
be handled by its specified transformer. However src_include is now
mandatory in that case, so non-local paths can be processed
by the specified transformer is warranted