### PR TITLE
feat: support data-fullsize attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divriots/jampack",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "cache-version": {
     "img": "v1",
     "img-ext": "v1"

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -278,6 +278,10 @@ async function processImage(
     return;
   }
 
+  const fullSizeRaw = img.attr('data-fullsize');
+  if (typeof fullSizeRaw !== undefined) img.removeAttr('data-fullsize');
+  const fullSize = !!fullSizeRaw && parseInt(fullSizeRaw) > 0;
+
   const config = state.options;
 
   if (
@@ -365,6 +369,7 @@ async function processImage(
         )
       )
         break;
+      if (fullSize) return;
       let attrib_width = getIntAttr(img, 'width');
       if (!attrib_width) {
         state.reportIssue(htmlfile, {
@@ -604,7 +609,7 @@ async function processImage(
     // If srcset are set, don't touch it.
     // The compress pass will compress the images
     // of the srcset
-  } else {
+  } else if (!fullSize) {
     const new_srcset = await generateSrcSet(
       state,
       htmlfile,


### PR DESCRIPTION
Instructs jampack not to do srcset manipulations on the given
image element
