### PR TITLE
Fix hang on deno

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ program
     if (options.fail && state.issues.size > 0) {
       exit(1);
     }
+    exit(0);
   });
 
 program.parse();


### PR DESCRIPTION
This properly exits the script on a succesful run, avoiding the hang previously occurring on Deno.