### PR TITLE
feat: add vfs support and onAnalysedFile callbacks

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,6 +1,6 @@
 import { hashSync as hasha } from 'hasha';
 import path from 'path';
-import * as fs from 'fs/promises';
+import * as fsp from 'fs/promises';
 import { GlobalState } from './state.js';
 import { CACHE_VERSIONS } from './packagejson.js';
 
@@ -16,6 +16,7 @@ function getCacheFolder(state: GlobalState): string {
 
 async function cleanCache(state: GlobalState, full?: boolean) {
   const CACHE_FOLDER = getCacheFolder(state);
+  const fs = state.vfs ?? fsp;
 
   if (full) {
     try {
@@ -98,6 +99,7 @@ async function getFromCache(
   if (state.args.nocache) {
     return undefined;
   }
+  const fs = state.vfs ?? fsp;
 
   const location = getLocation(state, hash, category);
 
@@ -124,6 +126,7 @@ async function addToCache(
   if (state.args.nocache) {
     return;
   }
+  const fs = state.vfs ?? fsp;
 
   const location = getLocation(state, hash, category);
   await fs.mkdir(location, { recursive: true });

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -1,5 +1,5 @@
 import { Stats } from 'fs';
-import * as fs from 'fs/promises';
+import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { formatBytes } from './utils.js';
 import { GlobalState, ReportItem } from './state.js';
@@ -16,6 +16,7 @@ const processFile = async (
   stats: Stats
 ): Promise<void> => {
   let writeData: Buffer | string | undefined = undefined;
+  const fs = state.vfs ?? fsp;
 
   try {
     const ext = path.extname(file);
@@ -85,6 +86,7 @@ export async function compressFolder(
   state: GlobalState,
   exclude?: string
 ): Promise<void> {
+  const fs = state.vfs ?? fsp;
   const spinner = ora(getProgressText(state)).start();
 
   const globs = ['**/**', '!_jampack/**']; // Exclude jampack folder because already compressed

--- a/src/optimizers/img-external.ts
+++ b/src/optimizers/img-external.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as fs from 'fs/promises';
+import * as fsp from 'fs/promises';
 import { GlobalState } from '../state.js';
 import { hashSync as hasha } from 'hasha';
 import { fileTypeFromBuffer } from 'file-type';
@@ -115,7 +115,7 @@ export async function downloadExternalImage(
     path.join(state.dir, `_jampack/${contentHash}.${ext}`)
   );
 
-  await fs.writeFile(path.join(state.dir, htmlFolder, filename), buffer);
+  await (state.vfs??fsp).writeFile(path.join(state.dir, htmlFolder, filename), buffer);
 
   return filename;
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -46,6 +46,10 @@ export class GlobalState {
   };
   summaryByExtension: Record<string, Summary> = {};
 
+  vfs?: typeof import('fs/promises');
+
+  onAnalysedFile?: (file: string) => void;
+
   reportIssue(sourceFile: string, issue: Issue) {
     let issueList = this.issues.get(sourceFile);
     if (issueList === undefined) {


### PR DESCRIPTION
- to support in-memory processing (e.g. using memfs)
- to support gc'ing cheerio large objects between large files