### PR TITLE
fix(resource): decode percent-encoded URLs before file lookup

### DIFF
--- a/src/utils/resource.ts
+++ b/src/utils/resource.ts
@@ -136,10 +136,12 @@ export class Resource {
       throw new Error(`Invalid src format "${src}"`);
     }
 
+    const pathname = decodeURIComponent(u.pathname);
+
     const relativePath = path.join(
       state.dir,
       src.startsWith('/') ? '' : path.dirname(relativeFile),
-      u.pathname
+      pathname,
     );
     let absolutePath = path.resolve(relativePath);
 


### PR DESCRIPTION
This change addresses an issue where Jampack was unable to find local files when they were referenced in HTML using a percent-encoded URL.

By decoding the URI component before attempting to locate the file on the filesystem, Jampack can now correctly resolve paths containing special characters, aligning its behavior with common web servers like Caddy and NGINX.