### PR TITLE
fix(optimize): Fix image ratio issues

### DIFF
--- a/src/config-default.ts
+++ b/src/config-default.ts
@@ -5,7 +5,6 @@ const default_options: Options = {
     browserslist: 'defaults', // defaults = '> 0.5%, last 2 versions, Firefox ESR, not dead'
   },
   html: {
-    add_css_reset_as: 'off',
     sort_attributes: false,
   },
   css: {

--- a/src/config-types.ts
+++ b/src/config-types.ts
@@ -11,7 +11,6 @@ export type Options = {
     browserslist: string; // browserslist query string
   };
   html: {
-    add_css_reset_as: 'inline' | 'off'; // 'inline': adds "<style>:where(img){height:auto}</style>" on top of the <head>
     sort_attributes: boolean;
   };
   js: {
@@ -31,16 +30,16 @@ export type Options = {
     src_exclude: RegExp | null;
     external: {
       process:
-        | 'off' // Default
-        | 'download' // Experimental
-        | ((attrib_src: string) => Promise<string>); // Experimental
+      | 'off' // Default
+      | 'download' // Experimental
+      | ((attrib_src: string) => Promise<string>); // Experimental
       src_include: RegExp;
       src_exclude: RegExp | null;
     };
     cdn: {
       process:
-        | 'off' //default
-        | 'optimize';
+      | 'off' //default
+      | 'optimize';
       src_include: RegExp | null;
       src_exclude: RegExp | null;
       transformer?: UrlTransformer; // Custom 'unpic' cdn url transformer, if not present it will be determined by 'unpic' based on original url
@@ -70,11 +69,11 @@ export type Options = {
     lazyload: {
       when: // Default: 'below-the-fold'
       | 'never' // All iframes are loaded eagerly
-        | 'below-the-fold' // Iframe are lazy loaded only if they are below the fold
-        | 'always'; // Not recommended, but if you want to lazy load all iframes
+      | 'below-the-fold' // Iframe are lazy loaded only if they are below the fold
+      | 'always'; // Not recommended, but if you want to lazy load all iframes
       how: // Default: 'native'
       | 'native' // Using `loading="lazy" attribue on iframe tag
-        | 'js'; // Using IntersectionObserver. Requires ~1Ko of JS but is more precise than native lazyload
+      | 'js'; // Using IntersectionObserver. Requires ~1Ko of JS but is more precise than native lazyload
     };
   };
   video: {
@@ -82,8 +81,8 @@ export type Options = {
       // Only for videos with autoplay
       when: // Default: 'below-the-fold'
       | 'never' // All video are loaded eagerly
-        | 'below-the-fold' // videos are lazy loaded only if they are below the fold
-        | 'always'; // Not recommended
+      | 'below-the-fold' // videos are lazy loaded only if they are below the fold
+      | 'always'; // Not recommended
       how: 'js'; // Using IntersectionObserver. Requires ~1Ko of JS
     };
   };


### PR DESCRIPTION
In some cases, the images could have wrong image ratio because the attributes `width` and `height` are added to `<img>` tags for CLS optimisations.
